### PR TITLE
Add Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+os: linux
+dist: bionic
+language: java
+
+install:
+  - ant
+
+script:
+  - ant Example1
+  - ant Example2
+  - ant Example3
+  - ant Example4


### PR DESCRIPTION
- Add [Travis CI](https://travis-ci.com) setting: `.travis.yml`
- My sample build result: https://travis-ci.com/github/y-yu/JavaIsolationForest/builds/163737785
    - I don't know whether it's correct or not 🤔 

### Next actions if you would merged this PR

1. Go to https://travis-ci.com website (it's NOT `travis-ci.org`)
    - `travis-ci.org` has been already deprecated now so there is no reason to use it from now
2. Sign in Travis CI by your GitHub account OAuth

Since you would do those 👆 procedures you can show the build result of each Git commit or Github PR at https://travis-ci.com/github/Kanatoko/JavaIsolationForest/ from the **next commit**.
